### PR TITLE
Usage of splitup JEC sources uncertainties.

### DIFF
--- a/Configuration/python/artusWrapper.py
+++ b/Configuration/python/artusWrapper.py
@@ -401,7 +401,8 @@ class ArtusWrapper(object):
 		else:
 			epilogArguments += r"--log-files " + os.path.join(sepathRaw, "${DATASETNICK}", "${DATASETNICK}_job_${MY_JOBID}_log.txt") + " "
 		epilogArguments += r"--print-envvars ROOTSYS CMSSW_BASE DATASETNICK FILE_NAMES LD_LIBRARY_PATH "
-		epilogArguments += r"-c " + os.path.basename(self._configFilename) + " "
+		# epilogArguments += r"-c " + os.path.basename(self._configFilename) + " "
+		epilogArguments += r"--artusconfig " + self._args.artusconfig + " "
 		epilogArguments += "--nick $DATASETNICK "
 		epilogArguments += "-i $FILE_NAMES "
 		if not self._args.ld_library_paths is None:

--- a/Configuration/python/artusWrapper.py
+++ b/Configuration/python/artusWrapper.py
@@ -401,8 +401,7 @@ class ArtusWrapper(object):
 		else:
 			epilogArguments += r"--log-files " + os.path.join(sepathRaw, "${DATASETNICK}", "${DATASETNICK}_job_${MY_JOBID}_log.txt") + " "
 		epilogArguments += r"--print-envvars ROOTSYS CMSSW_BASE DATASETNICK FILE_NAMES LD_LIBRARY_PATH "
-		# epilogArguments += r"-c " + os.path.basename(self._configFilename) + " "
-		epilogArguments += r"--artusconfig " + self._args.artusconfig + " "
+		epilogArguments += r"-c " + os.path.basename(self._configFilename) + " "
 		epilogArguments += "--nick $DATASETNICK "
 		epilogArguments += "-i $FILE_NAMES "
 		if not self._args.ld_library_paths is None:

--- a/KappaAnalysis/interface/KappaSettings.h
+++ b/KappaAnalysis/interface/KappaSettings.h
@@ -187,6 +187,7 @@ public:
 	
 	IMPL_SETTING_STRINGLIST(JetEnergyCorrectionParameters);
 	IMPL_SETTING_DEFAULT(std::string, JetEnergyCorrectionUncertaintyParameters, "");
+	IMPL_SETTING_DEFAULT(std::string, JetEnergyCorrectionUncertaintySource, "");
 	IMPL_SETTING_DEFAULT(float, JetEnergyCorrectionUncertaintyShift, 0.0);
 	
 	IMPL_SETTING_DEFAULT(std::string, ValidJetsInput, "auto");

--- a/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
+++ b/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
@@ -77,7 +77,13 @@ public:
 		LOG(DEBUG) << "\tLoading JetCorrectionUncertainty from files...";
 		if (! settings.GetJetEnergyCorrectionUncertaintyParameters().empty())
 		{
-			JetCorrectorParameters *jecUncertaintyParameters = new JetCorrectorParameters(settings.GetJetEnergyCorrectionUncertaintyParameters(), settings.GetJetEnergyCorrectionUncertaintySource());
+			JetCorrectorParameters *jecUncertaintyParameters = NULL;
+			if (!settings.GetJetEnergyCorrectionUncertaintySource().empty()) {
+				jecUncertaintyParameters = new JetCorrectorParameters(settings.GetJetEnergyCorrectionUncertaintyParameters(), settings.GetJetEnergyCorrectionUncertaintySource());
+			}
+			else {
+				jecUncertaintyParameters = new JetCorrectorParameters(settings.GetJetEnergyCorrectionUncertaintyParameters());
+			}
 			jetCorrectionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
 			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintyParameters();
 		}

--- a/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
+++ b/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
@@ -25,6 +25,7 @@
    Required config tags:
    - JetEnergyCorrectionParameters (files containing the correction parameters in the right order)
    - JetEnergyCorrectionUncertaintyParameters (default: empty)
+   - JetEnergyCorrectionUncertaintySource (default "")
    - JetEnergyCorrectionUncertaintyShift (default 0.0)
    
    Required packages (unfortunately, nobody knows a tag):
@@ -76,7 +77,8 @@ public:
 		LOG(DEBUG) << "\tLoading JetCorrectionUncertainty from files...";
 		if (! settings.GetJetEnergyCorrectionUncertaintyParameters().empty())
 		{
-			jetCorrectionUncertainty = new JetCorrectionUncertainty(settings.GetJetEnergyCorrectionUncertaintyParameters());
+			JetCorrectorParameters *jecUncertaintyParameters = new JetCorrectorParameters(settings.GetJetEnergyCorrectionUncertaintyParameters(), settings.GetJetEnergyCorrectionUncertaintySource());
+			jetCorrectionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
 			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintyParameters();
 		}
 	}


### PR DESCRIPTION
Hi,
is this convenient and flexible enough for everybody to use JEC uncertainties.
You have to use the ...UncertaintySources...txt and then you can specify with
JetEnergyCorrectionUncertaintySource the source ('Total', 'Absolute') etc.
With JetEnergyCorrectionUncertaintyShift >/< 0. you choose the upwards/downwards
variation.

