### PR TITLE
Replicate docu

### DIFF
--- a/HarryPlotter/python/harryparser.py
+++ b/HarryPlotter/python/harryparser.py
@@ -16,6 +16,14 @@ class HarryParser(argparse.ArgumentParser):
 		kwargs["add_help"] = False
 		kwargs["conflict_handler"] = "resolve"
 		kwargs["fromfile_prefix_chars"] = "@"
+		kwargs["formatter_class"] = argparse.RawDescriptionHelpFormatter
+		kwargs["epilog"] = (
+			"Parameter replication: Several list parameters are internally matched by\n"
+			"  their indizes. If they are of different length, short parameter lists\n"
+			"  are replicated element wise to meet the required length. For example,\n"
+			"  setting the inputs i1, i2, i3 and weights w1, w2 creates the matching\n"
+			"  i1->w1, i2->w2 and i3->w1.\n"
+		)
 		kwargs.setdefault("parents", []).append(logger.loggingParser)
 		
 		super(HarryParser, self).__init__(**kwargs)

--- a/HarryPlotter/python/input_modules/inputroot.py
+++ b/HarryPlotter/python/input_modules/inputroot.py
@@ -45,7 +45,7 @@ class InputRoot(inputfile.InputFile):
 		self.input_options.add_argument("-z", "--z-expressions", type=str, nargs="+",
 		                                help="z-axis variable expression(s)")
 		self.input_options.add_argument("-w", "--weights", type=str, nargs="+", default="1.0",
-		                                help="Weight (cut) expression(s). [Default: %(default)s]")
+		                                help="Weight (cut) expression(s); subject to parameter replication. [Default: %(default)s]")
 		
 		self.input_options.add_argument("--x-bins", type=str, nargs='+', default=[None],
 		                                help="Binnings for x-axis. Possible inputs:\


### PR DESCRIPTION
See https://github.com/artus-analysis/Artus/issues/7.

The HarryPlotter ``-h`` option now includes a short description of how parameters are replicated and marks ``-w`` as being subject to it. In addition, the warnings from parameter replication have been condensed into a single line: this ensures that all relevant information is logged together even in a multithreaded context and highlights the dependency between parameters.