### PR TITLE
Making the ini script for Artus appliable for both bash and zsh

### DIFF
--- a/Configuration/scripts/ini_ArtusAnalysis.sh
+++ b/Configuration/scripts/ini_ArtusAnalysis.sh
@@ -23,7 +23,7 @@ fi
 
 
 # setup Kappa
-#source $ARTUSPATH/../KappaTools/Toolbox/scripts/ini_KappaTools.sh
+source $ARTUSPATH/../KappaTools/Toolbox/scripts/ini_KappaTools.sh
 
 # voms proxy path
 export X509_USER_PROXY=$HOME/.globus/x509up

--- a/Configuration/scripts/ini_ArtusAnalysis.sh
+++ b/Configuration/scripts/ini_ArtusAnalysis.sh
@@ -1,15 +1,29 @@
 #!/bin/bash
 
-# get path of Artus installation
+if [ -n "$BASH_VERSION" ]; then
+
+# get path of Artus installation for bash
 if [[ ${BASH_SOURCE[0]} == *"${CMSSW_BASE}/bin/"* || ${BASH_SOURCE[0]} == *"${CMSSW_BASE}/src/Artus/"* ]]; then
 	export ARTUSPATH=$CMSSW_BASE/src/Artus
 else
-	# get Artus dir relative to location of this script
+	# get Artus dir relative to location of this script for bash
 	export ARTUSPATH=$(readlink -f $(dirname $(readlink -f ${BASH_SOURCE[0]}))/../..)
 fi
 
+elif [ -n "$ZSH_VERSION" ]; then
+# get path of Artus installation for zsh
+if [[ ${0} == *"${CMSSW_BASE}/bin/"* || ${0} == *"${CMSSW_BASE}/src/Artus/"* ]]; then
+	export ARTUSPATH=$CMSSW_BASE/src/Artus
+else
+	# get Artus dir relative to location of this script for zsh
+	export ARTUSPATH=$(readlink -f -- $(dirname -- "$(readlink -f -- "${0}")")/../..)
+fi
+
+fi
+
+
 # setup Kappa
-source $ARTUSPATH/../KappaTools/Toolbox/scripts/ini_KappaTools.sh
+#source $ARTUSPATH/../KappaTools/Toolbox/scripts/ini_KappaTools.sh
 
 # voms proxy path
 export X509_USER_PROXY=$HOME/.globus/x509up

--- a/Configuration/scripts/ini_ArtusAnalysis.sh
+++ b/Configuration/scripts/ini_ArtusAnalysis.sh
@@ -2,22 +2,23 @@
 
 if [ -n "$BASH_VERSION" ]; then
 
-# get path of Artus installation for bash
-if [[ ${BASH_SOURCE[0]} == *"${CMSSW_BASE}/bin/"* || ${BASH_SOURCE[0]} == *"${CMSSW_BASE}/src/Artus/"* ]]; then
-	export ARTUSPATH=$CMSSW_BASE/src/Artus
-else
-	# get Artus dir relative to location of this script for bash
-	export ARTUSPATH=$(readlink -f $(dirname $(readlink -f ${BASH_SOURCE[0]}))/../..)
-fi
+	# get path of Artus installation for bash
+	if [[ ${BASH_SOURCE[0]} == *"${CMSSW_BASE}/bin/"* || ${BASH_SOURCE[0]} == *"${CMSSW_BASE}/src/Artus/"* ]]; then
+		export ARTUSPATH=$CMSSW_BASE/src/Artus
+	else
+		# get Artus dir relative to location of this script for bash
+		export ARTUSPATH=$(readlink -f $(dirname $(readlink -f ${BASH_SOURCE[0]}))/../..)
+	fi
 
 elif [ -n "$ZSH_VERSION" ]; then
-# get path of Artus installation for zsh
-if [[ ${0} == *"${CMSSW_BASE}/bin/"* || ${0} == *"${CMSSW_BASE}/src/Artus/"* ]]; then
-	export ARTUSPATH=$CMSSW_BASE/src/Artus
-else
-	# get Artus dir relative to location of this script for zsh
-	export ARTUSPATH=$(readlink -f -- $(dirname -- "$(readlink -f -- "${0}")")/../..)
-fi
+
+	# get path of Artus installation for zsh
+	if [[ ${0} == *"${CMSSW_BASE}/bin/"* || ${0} == *"${CMSSW_BASE}/src/Artus/"* ]]; then
+		export ARTUSPATH=$CMSSW_BASE/src/Artus
+	else
+		# get Artus dir relative to location of this script for zsh
+		export ARTUSPATH=$(readlink -f -- $(dirname -- "$(readlink -f -- "${0}")")/../..)
+	fi
 
 fi
 


### PR DESCRIPTION
I've updated the ini script for Artus, so it can be used on zsh and bash. I have tested it in both shells, but please check whether it behaves also for you as expected in case I missed something.

Similar changes must then be done for the ini script in KappaTools. If you wish, that I do the changes, please add me there as a contributor. I will then create my fork and make a pull request.