### PR TITLE
reduce log file size to a reasonable amount

### DIFF
--- a/Configuration/python/artusWrapper.py
+++ b/Configuration/python/artusWrapper.py
@@ -410,7 +410,7 @@ class ArtusWrapper(object):
 		
 		epilogArguments  = r"epilog arguments = "
 		epilogArguments += r"--disable-repo-versions "
-		#epilogArguments += r"--log-level debug "
+		epilogArguments += r"--log-level info "
 		if self._args.no_log_to_se:
 			epilogArguments += r"--log-files log.txt "
 		else:

--- a/Configuration/python/artusWrapper.py
+++ b/Configuration/python/artusWrapper.py
@@ -410,7 +410,7 @@ class ArtusWrapper(object):
 		
 		epilogArguments  = r"epilog arguments = "
 		epilogArguments += r"--disable-repo-versions "
-		epilogArguments += r"--log-level debug "
+		#epilogArguments += r"--log-level debug "
 		if self._args.no_log_to_se:
 			epilogArguments += r"--log-files log.txt "
 		else:

--- a/KappaAnalysis/interface/Consumers/KappaLambdaNtupleConsumer.h
+++ b/KappaAnalysis/interface/Consumers/KappaLambdaNtupleConsumer.h
@@ -83,7 +83,7 @@ public:
 			    (LambdaNtupleConsumer<TTypes>::GetFloatQuantities().count(quantity) == 0) &&
 			    (LambdaNtupleConsumer<TTypes>::GetDoubleQuantities().count(quantity) == 0))
 			{
-				LOG(DEBUG) << "\tQuantity \"" << quantity << "\" is tried to be taken from product.m_weights or product.m_optionalWeights.";
+				LOG(INFO) << "\tQuantity \"" << quantity << "\" is tried to be taken from product.m_weights or product.m_optionalWeights.";
 				LambdaNtupleConsumer<TTypes>::AddFloatQuantity( quantity, [quantity](event_type const & event, product_type const & product)
 				{
 					return SafeMap::GetWithDefault(product.m_weights, quantity, SafeMap::GetWithDefault(product.m_optionalWeights, quantity, 1.0));
@@ -92,7 +92,7 @@ public:
 			if ((boost::algorithm::icontains(quantity, "filter") || boost::algorithm::icontains(quantity, "cut")) &&
 			   (LambdaNtupleConsumer<TTypes>::GetFloatQuantities().count(quantity) == 0))
 			{
-				LOG(DEBUG) << "\tQuantity \"" << quantity << "\" is tried to be taken from prduct.fres (FilterResult).";
+				LOG(INFO) << "\tQuantity \"" << quantity << "\" is tried to be taken from prduct.fres (FilterResult).";
 				LambdaNtupleConsumer<TTypes>::AddIntQuantity( quantity, [quantity](event_type const & event, product_type const & product)
 				{
 					if (product.fres.GetDecisionEntry(quantity) != nullptr)

--- a/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
+++ b/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
@@ -63,13 +63,13 @@ public:
 		KappaProducerBase::Init(settings);
 		
 		// load correction parameters
-		LOG(DEBUG) << "\tLoading JetCorrectorParameters from files...";
+		LOG(INFO) << "\tLoading JetCorrectorParameters from files...";
 		std::vector<JetCorrectorParameters> jecParameters;
 		for (std::vector<std::string>::const_iterator jecParametersFile = settings.GetJetEnergyCorrectionParameters().begin();
 		     jecParametersFile != settings.GetJetEnergyCorrectionParameters().end(); ++jecParametersFile)
 		{
 			jecParameters.push_back(JetCorrectorParameters(*jecParametersFile));
-			LOG(DEBUG) << "\t\t" << *jecParametersFile;
+			LOG(INFO) << "\t\t" << *jecParametersFile;
 		}
 		if (jecParameters.size() > 0)
 		{
@@ -77,7 +77,7 @@ public:
 		}
 		
 		// initialise uncertainty calculation
-		LOG(DEBUG) << "\tLoading JetCorrectionUncertainty from files...";
+		LOG(INFO) << "\tLoading JetCorrectionUncertainty from files...";
 		if ((! settings.GetJetEnergyCorrectionUncertaintyParameters().empty()) &&
 		    (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0))
 		{
@@ -95,8 +95,8 @@ public:
 				LOG(FATAL) << "Invalid definition " << settings.GetJetEnergyCorrectionUncertaintySource() 
 				           << " in file " << settings.GetJetEnergyCorrectionUncertaintyParameters();
 			jetCorrectionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
-			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintySource();
-			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintyParameters();
+			LOG(INFO) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintySource();
+			LOG(INFO) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintyParameters();
 		}
 	}
 

--- a/KappaAnalysis/interface/Producers/TmvaClassificationMultiReaderBase.h
+++ b/KappaAnalysis/interface/Producers/TmvaClassificationMultiReaderBase.h
@@ -56,7 +56,7 @@ public:
 			//tmvaReader.emplace_back(new TMVA::Reader());
 			tmvaReader.push_back(std::make_shared<TMVA::Reader>());
 			m_inputExtractors.push_back(std::vector<float_extractor_lambda>());
-			LOG(DEBUG) << "Parse QuantitiyString " << std::endl << *quantity_str;
+			LOG(INFO) << "Parse QuantitiyString " << std::endl << *quantity_str;
 			
 			std::vector<std::string> quantity_number;
 			boost::algorithm::split(quantity_number, *quantity_str, boost::algorithm::is_any_of(";"));
@@ -79,7 +79,7 @@ public:
 				transform(splitted.begin(), splitted.end(), splitted.begin(),
 						[](std::string s) { return boost::algorithm::trim_copy(s); });
 				std::string lambdaQuantity = splitted.front();
-				LOG(DEBUG) << "Find lambdaQuantity: " << lambdaQuantity;
+				LOG(INFO) << "Find lambdaQuantity: " << lambdaQuantity;
 				if (LambdaNtupleConsumer<TTypes>::GetFloatQuantities().count(lambdaQuantity) > 0)
 				{
 					m_inputExtractors[input_index].push_back(SafeMap::Get(LambdaNtupleConsumer<TTypes>::GetFloatQuantities(), lambdaQuantity));
@@ -106,7 +106,7 @@ public:
 		
 		// loading TMVA weight files
 		assert((settings.*GetTmvaMethods)().size() == (settings.*GetTmvaWeights)().size());
-		LOG(DEBUG) << "\tLoading TMVA weight files...";
+		LOG(INFO) << "\tLoading TMVA weight files...";
 		int mvaMethodIndex = 0;
 		for(std::vector<std::string>::const_iterator method_str = (settings.*GetTmvaMethods)().begin();
 			 method_str != (settings.*GetTmvaMethods)().end(); ++method_str)
@@ -119,7 +119,7 @@ public:
 			
 			std::string tmvaMethod = boost::lexical_cast<std::string>(input_index) + method_splits.back() + boost::lexical_cast<std::string>(mvaMethodIndex);
 			std::string tmvaWeights = (settings.*GetTmvaWeights)()[mvaMethodIndex];
-			LOG(DEBUG) << "\t\tmethod: " << tmvaMethod << ", weight file: " << tmvaWeights;
+			LOG(INFO) << "\t\tmethod: " << tmvaMethod << ", weight file: " << tmvaWeights;
 			tmvaReader[input_index]->BookMVA(tmvaMethod, tmvaWeights);
 			mvaMethodIndex += 1;
 		}

--- a/KappaAnalysis/interface/Producers/TmvaClassificationReaderBase.h
+++ b/KappaAnalysis/interface/Producers/TmvaClassificationReaderBase.h
@@ -82,12 +82,12 @@ public:
 		
 		// loading TMVA weight files
 		assert((settings.*GetTmvaMethods)().size() == (settings.*GetTmvaWeights)().size());
-		LOG(DEBUG) << "\tLoading TMVA weight files...";
+		LOG(INFO) << "\tLoading TMVA weight files...";
 		for (size_t mvaMethodIndex = 0; mvaMethodIndex < (settings.*GetTmvaMethods)().size(); ++mvaMethodIndex)
 		{
 			std::string tmvaMethod = (settings.*GetTmvaMethods)()[mvaMethodIndex]+ boost::lexical_cast<std::string>(mvaMethodIndex);
 			std::string tmvaWeights = (settings.*GetTmvaWeights)()[mvaMethodIndex];
-			LOG(DEBUG) << "\t\tmethod: " << tmvaMethod << ", weight file: " << tmvaWeights;
+			LOG(INFO) << "\t\tmethod: " << tmvaMethod << ", weight file: " << tmvaWeights;
 			tmvaReader.BookMVA(tmvaMethod, tmvaWeights);
 		}
 	}

--- a/KappaAnalysis/src/Producers/EventWeightProducer.cc
+++ b/KappaAnalysis/src/Producers/EventWeightProducer.cc
@@ -11,7 +11,7 @@ std::string EventWeightProducer::GetProducerId() const {
 
 EventWeightProducer::~EventWeightProducer()
 {
-	LOG(DEBUG) << "Constructed event weight from indidual weights ("
+	LOG(INFO) << "Constructed event weight from indidual weights ("
 	           << boost::algorithm::join(m_weightNames, ", ")
 	           << ") in the pipeline \"" << pipelineName << "\".";
 }

--- a/KappaAnalysis/src/Producers/PUWeightProducer.cc
+++ b/KappaAnalysis/src/Producers/PUWeightProducer.cc
@@ -12,8 +12,8 @@ void PUWeightProducer::Init(KappaSettings const& settings) {
 	KappaProducerBase::Init(settings);
 
 	const std::string histogramName = "pileup";
-	LOG(DEBUG) << "\tLoading pile-up weights from files...";
-	LOG(DEBUG) << "\t\t" << settings.GetPileupWeightFile() << "/" << histogramName;
+	LOG(INFO) << "\tLoading pile-up weights from files...";
+	LOG(INFO) << "\t\t" << settings.GetPileupWeightFile() << "/" << histogramName;
 	TFile file(settings.GetPileupWeightFile().c_str(), "READONLY");
 	TH1D* pileupHistogram = dynamic_cast<TH1D*>(file.Get(histogramName.c_str()));
 


### PR DESCRIPTION
Dear Artus users,

we currently run all jobs in debug mode:
https://github.com/artus-analysis/Artus/blob/Kappa_2_1/Configuration/python/artusWrapper.py#L417

Because up to now most modules even with debug settings were not that verbose we didn't pay so much attention. But this has changed and the logfiles grow to gigabytes. Anyway, a batch system is not something where one should debug its jobs, this should rather be done locally.

Does anyone veto against a merge?

Cheers,
Raphael