### PR TITLE
Debug flags in buildfiles

### DIFF
--- a/Configuration/BuildFile.xml
+++ b/Configuration/BuildFile.xml
@@ -1,4 +1,3 @@
-<Flags CXXFLAGS="-g" />
 <Flags LDFLAGS="-rdynamic" />
 <use name="root"/>
 <use name="boost"/>

--- a/Consumer/BuildFile.xml
+++ b/Consumer/BuildFile.xml
@@ -1,4 +1,3 @@
-<Flags CXXFLAGS="-g" />
 <Flags LDFLAGS="-rdynamic" />
 <use name="root"/>
 <use name="boost"/>

--- a/Core/BuildFile.xml
+++ b/Core/BuildFile.xml
@@ -1,4 +1,3 @@
-<Flags CXXFLAGS="-g" />
 <Flags LDFLAGS="-rdynamic" />
 <use name="root"/>
 <use name="boost"/>

--- a/Example/BuildFile.xml
+++ b/Example/BuildFile.xml
@@ -1,4 +1,3 @@
-<Flags CXXFLAGS="-g" />
 <Flags LDFLAGS="-rdynamic" />
 
 <use name="root"/>

--- a/Example/bin/BuildFile.xml
+++ b/Example/bin/BuildFile.xml
@@ -4,7 +4,6 @@
 	<use   name="Artus/Configuration"/>
 	<use   name="Artus/Consumer"/>
 	<use   name="Artus/Example"/>
-	<Flags CXXFLAGS="-g" />
 	<Flags LDFLAGS="-rdynamic" />
 </bin>
 

--- a/Filter/BuildFile.xml
+++ b/Filter/BuildFile.xml
@@ -1,4 +1,3 @@
-<Flags CXXFLAGS="-g" />
 <Flags LDFLAGS="-rdynamic" />
 
 <use   name="root"/>

--- a/KappaAnalysis/BuildFile.xml
+++ b/KappaAnalysis/BuildFile.xml
@@ -1,4 +1,3 @@
-<Flags CXXFLAGS="-g" />
 <Flags LDFLAGS="-rdynamic" />
 <Flags LDFLAGS="-Lsrc/Kappa/lib -lKappa" />
 

--- a/Provider/BuildFile.xml
+++ b/Provider/BuildFile.xml
@@ -1,4 +1,3 @@
-<Flags CXXFLAGS="-g" />
 <Flags LDFLAGS="-rdynamic" />
 
 <use   name="boost"/>

--- a/Utility/BuildFile.xml
+++ b/Utility/BuildFile.xml
@@ -1,4 +1,3 @@
-<Flags CXXFLAGS="-g" />
 <Flags LDFLAGS="-rdynamic" />
 
 <use name="KappaTools/Toolbox" />


### PR DESCRIPTION
Hi,

in a little discussion with Raphael we found out that dropping the debug-flags as default compile options from Artus and KITHiggsToTauTau reduces the size of the corresponding libraries quite significantly [*]. As these libraries are also packed and copied for every single submission we run, I was wondering if we can't altogether drop these flags as default. After all in the "normal" everyday work (i.e. when not developing new modules) we should not really need the additional information provided by them.
When needed the flags could be enabled for the compilation without needing to modify the buildfiles by handing the additional option USER_CXXFLAGS="-g" to scram/gmake. (If already compiled before it might be necessary to force a recompile with -B.)

What do you think?

Cheers,
Rene

[*]
libHiggAnalysisKITHiggsToTauTau.so from 116 Mb to 5,2 Mb
libArtusKappa from 88 Mb to 2.3 Mb