### PR TITLE
AddHistograms/SumOfHistograms

### DIFF
--- a/HarryPlotter/python/analysis_modules/addhistograms.py
+++ b/HarryPlotter/python/analysis_modules/addhistograms.py
@@ -19,60 +19,60 @@ class AddHistograms(analysisbase.AnalysisBase):
 
 		self.add_histograms_options = parser.add_argument_group("{} options".format(self.name()))
 		self.add_histograms_options.add_argument(
-				"--histogram-nicks", nargs="+",
+				"--add-nicks", nargs="+",
 				help="Nick names (whitespace separated) for the histograms to be added"
 		)
 		self.add_histograms_options.add_argument(
-				"--sum-scale-factors", nargs="+",
+				"--add-scale-factors", nargs="+",
 				help="Scale factor (whitespace separated) for the histograms to be added [Default: 1]."
 		)
 		self.add_histograms_options.add_argument(
-				"--sum-result-nicks", nargs="+",
+				"--add-result-nicks", nargs="+",
 				help="Nick names for the resulting sum histograms."
 		)
 
 	def prepare_args(self, parser, plotData):
 		super(AddHistograms, self).prepare_args(parser, plotData)
-		self.prepare_list_args(plotData, ["histogram_nicks", "sum_result_nicks","sum_scale_factors"])
+		self.prepare_list_args(plotData, ["add_nicks", "add_result_nicks", "add_scale_factors"])
 		
-		for index, (histogram_nicks, sum_result_nick,sum_scale_factors) in enumerate(zip(
-				*[plotData.plotdict[k] for k in ["histogram_nicks", "sum_result_nicks","sum_scale_factors"]]
+		for index, (add_nicks, add_result_nick, add_scale_factors) in enumerate(zip(
+				*[plotData.plotdict[k] for k in ["add_nicks", "add_result_nicks", "add_scale_factors"]]
 		)):
-			plotData.plotdict["histogram_nicks"][index] = histogram_nicks.split()
-			if sum_scale_factors is None:
-				plotData.plotdict["sum_scale_factors"][index] = [1] * len(histogram_nicks.split())
+			plotData.plotdict["add_nicks"][index] = add_nicks.split()
+			if add_scale_factors is None:
+				plotData.plotdict["add_scale_factors"][index] = [1] * len(add_nicks.split())
 			else:
-				plotData.plotdict["sum_scale_factors"][index] = [float(sum_scale_factor) for sum_scale_factor in sum_scale_factors.split()]
-			if sum_result_nick is None:
-				plotData.plotdict["sum_result_nicks"][index] = "sum_{}".format(
-						"_".join(plotData.plotdict["histogram_nicks"][index]),
+				plotData.plotdict["add_scale_factors"][index] = [float(add_scale_factor) for add_scale_factor in add_scale_factors.split()]
+			if add_result_nick is None:
+				plotData.plotdict["add_result_nicks"][index] = "add_{}".format(
+						"_".join(plotData.plotdict["add_nicks"][index]),
 				)
-			if not plotData.plotdict["sum_result_nicks"][index] in plotData.plotdict["nicks"]:
+			if not plotData.plotdict["add_result_nicks"][index] in plotData.plotdict["nicks"]:
 				plotData.plotdict["nicks"].insert(
-						plotData.plotdict["nicks"].index(plotData.plotdict["histogram_nicks"][index][0]),
-						plotData.plotdict["sum_result_nicks"][index]
+						plotData.plotdict["nicks"].index(plotData.plotdict["add_nicks"][index][0]),
+						plotData.plotdict["add_result_nicks"][index]
 				)
 
 	def run(self, plotData=None):
 		super(AddHistograms, self).run(plotData)
 		
-		for histogram_nicks, sum_result_nick,sum_scale_factors in zip(
-				*[plotData.plotdict[k] for k in ["histogram_nicks", "sum_result_nicks","sum_scale_factors"]]
+		for add_nicks, add_result_nick, add_scale_factors in zip(
+				*[plotData.plotdict[k] for k in ["add_nicks", "add_result_nicks","add_scale_factors"]]
 		):
-			sum_histogram = None
-			log.debug("AddHistograms: "+sum_result_nick+" = "+(" + ".join([str(scale)+"*"+nick for nick, scale in zip(histogram_nicks, sum_scale_factors)])))
-			for nick, sum_scale_factor in zip(histogram_nicks, sum_scale_factors):
+			add_histogram = None
+			log.debug("AddHistograms: "+add_result_nick+" = "+(" + ".join([str(scale)+"*"+nick for nick, scale in zip(add_nicks, add_scale_factors)])))
+			for nick, add_scale_factor in zip(add_nicks, add_scale_factors):
 				root_object = plotData.plotdict["root_objects"][nick]
 				assert(isinstance(root_object, ROOT.TH1))
-				if sum_histogram is None:
-					sum_histogram = root_object.Clone(
-							"sum_" + hashlib.md5("_".join([str(histogram_nicks), sum_result_nick])).hexdigest()
+				if add_histogram is None:
+					add_histogram = root_object.Clone(
+							"add_" + hashlib.md5("_".join([str(add_nicks), add_result_nick])).hexdigest()
 					)
-					sum_histogram.Scale(sum_scale_factor)
-					sum_histogram.SetDirectory(0)
+					add_histogram.Scale(add_scale_factor)
+					add_histogram.SetDirectory(0)
 				else:
-					sum_histogram.Add(root_object, sum_scale_factor)
-					sum_histogram.SetDirectory(0)
+					add_histogram.Add(root_object, add_scale_factor)
+					add_histogram.SetDirectory(0)
 
-			plotData.plotdict["root_objects"][sum_result_nick] = sum_histogram
+			plotData.plotdict["root_objects"][add_result_nick] = add_histogram
 

--- a/HarryPlotter/python/analysis_modules/blindingpolicy.py
+++ b/HarryPlotter/python/analysis_modules/blindingpolicy.py
@@ -12,7 +12,7 @@ import ROOT
 import math
 
 import Artus.HarryPlotter.analysisbase as analysisbase
-from Artus.HarryPlotter.analysis_modules.sumofhistograms import SumOfHistograms
+import Artus.HarryPlotter.utility.roottools as roottools
 
 class BlindingPolicy(analysisbase.AnalysisBase):
 	def __init__(self):
@@ -60,9 +60,9 @@ class BlindingPolicy(analysisbase.AnalysisBase):
 		                                                         plotData.plotdict["blinding_method"],
 		                                                         plotData.plotdict["blinding_parameters"] ):
 			
-			signal = SumOfHistograms.return_sum_of_histograms([plotData.plotdict["root_objects"][nick] for nick in signal_nick.split(" ")])
+			signal = roottools.RootTools.add_root_histograms(*[plotData.plotdict["root_objects"][nick] for nick in signal_nick.split(" ")])
 			new_histogram = signal.Clone(result_nick)
-			background = SumOfHistograms.return_sum_of_histograms([plotData.plotdict["root_objects"][nick] for nick in background_nick.split(" ")])
+			background = roottools.RootTools.add_root_histograms(*[plotData.plotdict["root_objects"][nick] for nick in background_nick.split(" ")])
 			expression = self.get_blinding_expression(method)
 
 			if(signal.GetNbinsX() != background.GetNbinsX()):

--- a/HarryPlotter/python/analysis_modules/fullintegral.py
+++ b/HarryPlotter/python/analysis_modules/fullintegral.py
@@ -13,7 +13,7 @@ import ROOT
 import math
 import Artus.Utility.jsonTools as jsonTools
 import Artus.HarryPlotter.analysisbase as analysisbase
-from Artus.HarryPlotter.analysis_modules.sumofhistograms import SumOfHistograms
+import Artus.HarryPlotter.utility.roottools as roottools
 
 class FullIntegral(analysisbase.AnalysisBase):
 	
@@ -52,7 +52,7 @@ class FullIntegral(analysisbase.AnalysisBase):
 		category = plotData.plotdict.get("category", "NoCategory")
 		if plotData.plotdict.get("full_integral_task", "standard") == "standard":
 			for integral_nicks in plotData.plotdict["full_integral_nicks"]:
-				signal = SumOfHistograms.return_sum_of_histograms([plotData.plotdict["root_objects"][nick] for nick in integral_nicks.split(" ")])
+				signal = roottools.RootTools.add_root_histograms(*[plotData.plotdict["root_objects"][nick] for nick in integral_nicks.split(" ")])
 				integral = 0
 				for x_bin in xrange(1, signal.GetNbinsX()+1):
 					#log.info("access bin %i"%x_bin)

--- a/HarryPlotter/python/analysis_modules/signaloverbackgroundintegral.py
+++ b/HarryPlotter/python/analysis_modules/signaloverbackgroundintegral.py
@@ -12,7 +12,7 @@ import ROOT
 import math
 
 import Artus.HarryPlotter.analysisbase as analysisbase
-from Artus.HarryPlotter.analysis_modules.sumofhistograms import SumOfHistograms
+import Artus.HarryPlotter.utility.roottools as roottools
 
 class SignalOverBackgroundIntegral(analysisbase.AnalysisBase):
 	def __init__(self):
@@ -65,9 +65,9 @@ class SignalOverBackgroundIntegral(analysisbase.AnalysisBase):
 																	plotData.plotdict["sob_integral_direction"],
 																	plotData.plotdict["sob_integral_method"]):
 
-			signal = SumOfHistograms.return_sum_of_histograms([plotData.plotdict["root_objects"][nick] for nick in signal_nick.split(" ")])
+			signal = roottools.RootTools.add_root_histograms(*[plotData.plotdict["root_objects"][nick] for nick in signal_nick.split(" ")])
 			#new_histogram = signal.Clone("storage_histogram")
-			background = SumOfHistograms.return_sum_of_histograms([plotData.plotdict["root_objects"][nick] for nick in background_nick.split(" ")])
+			background = roottools.RootTools.add_root_histograms(*[plotData.plotdict["root_objects"][nick] for nick in background_nick.split(" ")])
 			calculation_function = self.get_function(method)
 			if(signal.GetNbinsX() != background.GetNbinsX()):
 				log.fatal("Signal histogram " + signal + " has a different binning than " + background )

--- a/HarryPlotter/python/analysis_modules/sumofhistograms.py
+++ b/HarryPlotter/python/analysis_modules/sumofhistograms.py
@@ -7,42 +7,54 @@ import logging
 import Artus.Utility.logger as logger
 log = logging.getLogger(__name__)
 
-import hashlib
-import ROOT
-
 import Artus.HarryPlotter.analysisbase as analysisbase
+import Artus.HarryPlotter.utility.roottools as roottools
 
 
 class SumOfHistograms(analysisbase.AnalysisBase):
+	"""Create sum of histograms. This module does exactly the same as AddHistograms, but is can enable different addition steps together with this module."""
+	
 	def __init__(self):
 		super(SumOfHistograms, self).__init__()
 
 	def modify_argument_parser(self, parser, args):
 		super(SumOfHistograms, self).modify_argument_parser(parser, args)
-		
-		self.sum_histograms_options = parser.add_argument_group("Options for adding up histograms")
-		self.sum_histograms_options.add_argument("--sum-nicks", nargs="+",
-				help="Nick names for the histograms to sum up, whitespace separated.")
-		self.sum_histograms_options.add_argument("--sum-scale-factors", nargs="+", default=["1.0"],
-				help="Scale factors for the histograms to sum up, whitespace separated.")
-		self.sum_histograms_options.add_argument("--sum-result-nicks", nargs="+", default=[None],
-				help="Nick names for the resulting histograms.")
+
+		self.sum_histograms_options = parser.add_argument_group("{} options".format(self.name()))
+		self.sum_histograms_options.add_argument(
+				"--sum-nicks", nargs="+",
+				help="Nick names (whitespace separated) for the histograms to be added"
+		)
+		self.sum_histograms_options.add_argument(
+				"--sum-scale-factors", nargs="+",
+				help="Scale factor (whitespace separated) for the histograms to be added [Default: 1]."
+		)
+		self.sum_histograms_options.add_argument(
+				"--sum-result-nicks", nargs="+",
+				help="Nick names for the resulting sum histograms."
+		)
 
 	def prepare_args(self, parser, plotData):
 		super(SumOfHistograms, self).prepare_args(parser, plotData)
+		self.prepare_list_args(plotData, ["sum_nicks", "sum_result_nicks", "sum_scale_factors"])
 		
-		self.prepare_list_args(plotData, ["sum_nicks", "sum_scale_factors", "sum_result_nicks"])
-		
-		plotData.plotdict["sum_nicks"] = [[nick for nick in nicks.split() if nick in plotData.plotdict["root_objects"]] for nicks in plotData.plotdict["sum_nicks"]]
-		
-		plotData.plotdict["sum_scale_factors"] = [[float(factor) for factor in factors.split()] for factors in plotData.plotdict["sum_scale_factors"]]
-		for index, (nicks, factors) in enumerate(zip(plotData.plotdict["sum_nicks"],
-		                                             plotData.plotdict["sum_scale_factors"])):
-			plotData.plotdict["sum_scale_factors"][index] = (factors * len(nicks))[:len(nicks)]
-		
-		for index, nick in enumerate(plotData.plotdict["sum_result_nicks"]):
-			if not nick:
-				plotData.plotdict["sum_result_nicks"][index] = "_".join(plotData.plotdict["sum_nicks"][index])
+		for index, (sum_nicks, sum_result_nick, sum_scale_factors) in enumerate(zip(
+				*[plotData.plotdict[k] for k in ["sum_nicks", "sum_result_nicks", "sum_scale_factors"]]
+		)):
+			plotData.plotdict["sum_nicks"][index] = sum_nicks.split()
+			if sum_scale_factors is None:
+				plotData.plotdict["sum_scale_factors"][index] = [1] * len(sum_nicks.split())
+			else:
+				plotData.plotdict["sum_scale_factors"][index] = [float(sum_scale_factor) for sum_scale_factor in sum_scale_factors.split()]
+			if sum_result_nick is None:
+				plotData.plotdict["sum_result_nicks"][index] = "sum_{}".format(
+						"_".join(plotData.plotdict["sum_nicks"][index]),
+				)
+			if not plotData.plotdict["sum_result_nicks"][index] in plotData.plotdict["nicks"]:
+				plotData.plotdict["nicks"].insert(
+						plotData.plotdict["nicks"].index(plotData.plotdict["sum_nicks"][index][0]),
+						plotData.plotdict["sum_result_nicks"][index]
+				)
 
 	@staticmethod
 	def return_sum_of_histograms(histograms, scale_factors=None, new_histogram_name=None):
@@ -67,16 +79,13 @@ class SumOfHistograms(analysisbase.AnalysisBase):
 	def run(self, plotData=None):
 		super(SumOfHistograms, self).run(plotData)
 		
-		for sum_nicks, sum_scale_factors, sum_result_nick in zip(plotData.plotdict["sum_nicks"],
-		                                                         plotData.plotdict["sum_scale_factors"],
-		                                                         plotData.plotdict["sum_result_nicks"]):
+		for sum_nicks, sum_scale_factors, sum_result_nick in zip(
+				*[plotData.plotdict[k] for k in ["sum_nicks", "sum_scale_factors", "sum_result_nicks"]]
+		):
 			
 			log.debug("SumOfHistograms: "+sum_result_nick+" = "+(" + ".join([str(scale)+"*"+nick for nick, scale in zip(sum_nicks, sum_scale_factors)])))
-			plotData.plotdict["root_objects"][sum_result_nick] = self.return_sum_of_histograms( [plotData.plotdict["root_objects"][nick] for nick in sum_nicks],
-			                                                                               sum_scale_factors)
-			
-			# insert new nick between the existing ones
-			if sum_result_nick not in plotData.plotdict["nicks"]:
-				plotData.plotdict["nicks"].insert(max([plotData.plotdict["nicks"].index(nick) for nick in sum_nicks]),
-				                                  sum_result_nick)
+			plotData.plotdict["root_objects"][sum_result_nick] = roottools.RootTools.add_root_histograms(
+					*[plotData.plotdict["root_objects"][nick] for nick in sum_nicks],
+					scale_factors=sum_scale_factors
+			)
 

--- a/HarryPlotter/python/analysis_modules/sumofhistograms.py
+++ b/HarryPlotter/python/analysis_modules/sumofhistograms.py
@@ -56,26 +56,6 @@ class SumOfHistograms(analysisbase.AnalysisBase):
 						plotData.plotdict["sum_result_nicks"][index]
 				)
 
-	@staticmethod
-	def return_sum_of_histograms(histograms, scale_factors=None, new_histogram_name=None):
-		if(new_histogram_name == None):
-			sum_nicks = []
-			for histogram in histograms:
-				sum_nicks.append( histogram.GetName())
-			new_histogram_name = "histogram_" + hashlib.md5("_".join(sum_nicks)).hexdigest()
-		if(scale_factors == None):
-			scale_factors = [1] * len(histograms)
-
-		new_histogram = None
-		for histogram, scale_factor in zip(histograms, scale_factors):
-			if isinstance(histogram, ROOT.TH1):
-				if new_histogram == None:
-					new_histogram = histogram.Clone(new_histogram_name)
-					new_histogram.Scale(scale_factor)
-				else:
-					new_histogram.Add(histogram, scale_factor)
-		return new_histogram
-
 	def run(self, plotData=None):
 		super(SumOfHistograms, self).run(plotData)
 		


### PR DESCRIPTION
I propose some changes of the HarryPlotter modules AddHistograms and SumOfHistograms to be merged into the master. This is reated to the (closed) issue https://github.com/artus-analysis/Artus/issues/17.

I have the situation, where I need both modules for adding up histograms, because I wand to run another module between the additions. I found, that some parameters of both histograms have been identical such that is was not possible to use these modules with different inputs. Therefore I changed the parameters such that they differ now:

AddHistograms:
--add-nicks (was formerly --histogram-nicks)
--add-scale-factors (was formerly --sum-scale-factors)
--add-result-nicks (was formerly --sum-result-nicks)

SumOfHistograms:
--sum-nicks (unchanged)
--sum-scale-factors (unchanged)
--sum-result-nicks (unchanged)

At the same time I made the modules use the same function for adding up histograms: roottools.RootTools.add_root_histograms. I removed SumOfHistograms.return_sum_of_histograms which became obsolete in this step.

I case there are no objections, I would like to merge these changes into the master on Monday. Note, that I only adjusted the plotting configs that are committed.