### PR TITLE
Stitching weights configurable

### DIFF
--- a/KappaAnalysis/interface/KappaSettings.h
+++ b/KappaAnalysis/interface/KappaSettings.h
@@ -347,4 +347,7 @@ public:
 	IMPL_SETTING_DEFAULT(float, ZMass, 91.1876f);
 	IMPL_SETTING(float, ZMassRange);
 	IMPL_SETTING_DEFAULT(bool, VetoMultipleZs, true);
+
+	// Needed by SampleStitchingWeightProducer
+	IMPL_SETTING_STRINGLIST_DEFAULT(StitchingWeights, {});
 };

--- a/KappaAnalysis/interface/KappaSettings.h
+++ b/KappaAnalysis/interface/KappaSettings.h
@@ -349,5 +349,5 @@ public:
 	IMPL_SETTING_DEFAULT(bool, VetoMultipleZs, true);
 
 	// Needed by SampleStitchingWeightProducer
-	IMPL_SETTING_STRINGLIST_DEFAULT(StitchingWeights, {});
+	IMPL_SETTING_STRINGLIST(StitchingWeights);
 };

--- a/KappaAnalysis/interface/KappaSettings.h
+++ b/KappaAnalysis/interface/KappaSettings.h
@@ -350,4 +350,5 @@ public:
 
 	// Needed by SampleStitchingWeightProducer
 	IMPL_SETTING_STRINGLIST(StitchingWeights);
+	IMPL_SETTING_STRINGLIST_DEFAULT(StitchingWeightsHighMass, {});
 };

--- a/KappaAnalysis/interface/Producers/SampleStitchingWeightProducer.h
+++ b/KappaAnalysis/interface/Producers/SampleStitchingWeightProducer.h
@@ -26,8 +26,6 @@ public:
 
 private:
 
-	std::vector<std::string>& (KappaSettings::*GetStitchingWeights)(void) const;
-
 	std::map<size_t, std::vector<float> > stitchingWeightsByIndex;
 	std::map<std::string, std::vector<float> > stitchingWeightsByName;
 

--- a/KappaAnalysis/interface/Producers/SampleStitchingWeightProducer.h
+++ b/KappaAnalysis/interface/Producers/SampleStitchingWeightProducer.h
@@ -26,7 +26,9 @@ public:
 
 private:
 
-	std::map<size_t, std::vector<float> > stitchingWeightsByIndex;
-	std::map<std::string, std::vector<float> > stitchingWeightsByName;
+	std::map<size_t, std::vector<double> > stitchingWeightsByIndex;
+	std::map<size_t, std::vector<double> > stitchingWeightsHighMassByIndex;
+	std::map<std::string, std::vector<double> > stitchingWeightsByName;
+	std::map<std::string, std::vector<double> > stitchingWeightsHighMassByName;
 
 };

--- a/KappaAnalysis/interface/Producers/SampleStitchingWeightProducer.h
+++ b/KappaAnalysis/interface/Producers/SampleStitchingWeightProducer.h
@@ -2,6 +2,8 @@
 
 #include "Artus/KappaAnalysis/interface/KappaProducerBase.h"
 
+#include "Artus/Utility/interface/Utility.h"
+
 #include <boost/regex.hpp>
 
 /**
@@ -16,8 +18,17 @@ public:
 
 	std::string GetProducerId() const override;
 
+	virtual void Init(KappaSettings const& settings);
+
 	void Produce( KappaEvent const& event,
 			KappaProduct & product,
 			KappaSettings const& settings) const override;
+
+private:
+
+	std::vector<std::string>& (KappaSettings::*GetStitchingWeights)(void) const;
+
+	std::map<size_t, std::vector<float> > stitchingWeightsByIndex;
+	std::map<std::string, std::vector<float> > stitchingWeightsByName;
 
 };

--- a/KappaAnalysis/src/Producers/SampleStitchingWeightProducer.cc
+++ b/KappaAnalysis/src/Producers/SampleStitchingWeightProducer.cc
@@ -2,6 +2,8 @@
 #include "Artus/KappaAnalysis/interface/Producers/SampleStitchingWeightProducer.h"
 
 #include "Artus/Utility/interface/SafeMap.h"
+#include "Artus/Utility/interface/Utility.h"
+
 
 std::string SampleStitchingWeightProducer::GetProducerId() const
 {
@@ -10,33 +12,44 @@ std::string SampleStitchingWeightProducer::GetProducerId() const
 
 void SampleStitchingWeightProducer::Init(KappaSettings const& settings)
 {
-	stitchingWeightsByIndex = Utility::ParseMapTypes<size_t, double>(Utility::ParseVectorToMap(settings.GetStitchingWeights()),
-																	stitchingWeightsByName);
-	stitchingWeightsHighMassByIndex = Utility::ParseMapTypes<size_t, double>(Utility::ParseVectorToMap(settings.GetStitchingWeightsHighMass()),
-																	stitchingWeightsHighMassByName);
+	stitchingWeightsByIndex = Utility::ParseMapTypes<size_t, double>(
+			Utility::ParseVectorToMap(settings.GetStitchingWeights()),
+			stitchingWeightsByName
+	);
+	stitchingWeightsHighMassByIndex = Utility::ParseMapTypes<size_t, double>(
+			Utility::ParseVectorToMap(settings.GetStitchingWeightsHighMass()),
+			stitchingWeightsHighMassByName
+	);
 }
 
-void SampleStitchingWeightProducer::Produce( KappaEvent const& event,
-			KappaProduct & product,
-			KappaSettings const& settings) const
+void SampleStitchingWeightProducer::Produce(
+		KappaEvent const& event,
+		KappaProduct & product,
+		KappaSettings const& settings
+) const
 {
 	assert(event.m_genEventInfo != nullptr);
-
-	if(SafeMap::GetWithDefault(product.m_weights, std::string("crossSectionPerEventWeight"), -1.) <= 0.)
+	
+	if (! Utility::Contains(product.m_weights, std::string("crossSectionPerEventWeight")))
 	{
 		LOG(FATAL) << "Cross section not available or 0. Make sure that CrossSectionWeightProducer is run before SampleStitchingWeightProducer!";
 	}
-	else if(SafeMap::GetWithDefault(product.m_weights, std::string("numberGeneratedEventsWeight"), -1.) <= 0.)
+	if (! Utility::Contains(product.m_weights, std::string("numberGeneratedEventsWeight")))
 	{
 		LOG(FATAL) << "Number of generated events not available or 0. Make sure that NumberGeneratedEventsWeightProducer is run before SampleStitchingWeightProducer!";
 	}
+	
+	size_t nPartons = event.m_genEventInfo->lheNOutPartons >= 5 ? 0 : event.m_genEventInfo->lheNOutPartons;
+	
+	// take overlap of phase space into account for DY samples with M50 & M150
+	if ((product.m_genDiLeptonBoson.mass() >= 150.0) && (stitchingWeightsHighMassByIndex.size() > 0))
+	{
+		product.m_weights["sampleStitchingWeight"] = SafeMap::Get(stitchingWeightsHighMassByIndex, nPartons).at(0);
+	}
 	else
 	{
-		int nPartons = event.m_genEventInfo->lheNOutPartons >= 5 ? 0 : event.m_genEventInfo->lheNOutPartons;
-		// take overlap of phase space into account for DY samples with M50 & M150
-		if (product.m_genDiLeptonBoson.mass() >= 150.0 && stitchingWeightsHighMassByIndex.size() > 0)
-			product.m_weights["sampleStitchingWeight"] = SafeMap::Get(stitchingWeightsHighMassByIndex, size_t(nPartons)).at(0) / product.m_weights["numberGeneratedEventsWeight"] / product.m_weights["crossSectionPerEventWeight"];
-		else
-			product.m_weights["sampleStitchingWeight"] = SafeMap::Get(stitchingWeightsByIndex, size_t(nPartons)).at(0) / product.m_weights["numberGeneratedEventsWeight"] / product.m_weights["crossSectionPerEventWeight"];
+		product.m_weights["sampleStitchingWeight"] = SafeMap::Get(stitchingWeightsByIndex, nPartons).at(0);
 	}
+	
+	product.m_weights["sampleStitchingWeight"] /= (product.m_weights["numberGeneratedEventsWeight"] * product.m_weights["crossSectionPerEventWeight"]);
 }

--- a/KappaAnalysis/src/Producers/SampleStitchingWeightProducer.cc
+++ b/KappaAnalysis/src/Producers/SampleStitchingWeightProducer.cc
@@ -10,7 +10,7 @@ std::string SampleStitchingWeightProducer::GetProducerId() const
 
 void SampleStitchingWeightProducer::Init(KappaSettings const& settings)
 {
-	stitchingWeightsByIndex = Utility::ParseMapTypes<size_t, float>(Utility::ParseVectorToMap((settings.*GetStitchingWeights)()),
+	stitchingWeightsByIndex = Utility::ParseMapTypes<size_t, float>(Utility::ParseVectorToMap(settings.GetStitchingWeights()),
 																	stitchingWeightsByName);
 }
 
@@ -20,181 +20,17 @@ void SampleStitchingWeightProducer::Produce( KappaEvent const& event,
 {
 	assert(event.m_genEventInfo != nullptr);
 	
-	// reset the values of crossSectionPerEventWeight and numberGeneratedEventsWeight to default, since the stitching weight is
-	// computed taking into account those numbers
-	product.m_weights["crossSectionPerEventWeight"] = 1.0;
-	product.m_weights["numberGeneratedEventsWeight"] = 1.0;
-	
-	int nPartons = event.m_genEventInfo->lheNOutPartons >= 5 ? 0 : event.m_genEventInfo->lheNOutPartons;
-	product.m_optionalWeights["stitchWeight"] = SafeMap::Get(stitchingWeightsByIndex, size_t(nPartons)).at(0);
-	/*if (boost::regex_search(product.m_nickname, boost::regex("DY.?JetsToLLM(50|150)_RunIIFall15", boost::regex::icase | boost::regex::extended)))
+	if(SafeMap::GetWithDefault(product.m_weights, std::string("crossSectionPerEventWeight"), -1.) <= 0.)
 	{
-		if (product.m_genDiLeptonBoson.mass() < 150.0)
-		{
-			if ((nPartons == 0) || (nPartons >= 5))
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 2.43669e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 2.43669e-5;
-			}
-			else if (nPartons == 1)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.06292e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.06292e-5;
-			}
-			else if (nPartons == 2)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.10505e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.10505e-5;
-			}
-			else if (nPartons == 3)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.14799e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.14799e-5;
-			}
-			else
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 9.62135e-6;
-				product.m_optionalWeights["stitchWeightZTT"] = 9.62135e-6;
-			}
-		}
-		else
-		{
-			if ((nPartons == 0) || (nPartons >= 5))
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 2.43669e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.26276e-6;
-			}
-			else if (nPartons == 1)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.06292e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.18349e-6;
-			}
-			else if (nPartons == 2)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.10505e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.18854e-6;
-			}
-			else if (nPartons == 3)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.14799e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.19334e-6;
-			}
-			else
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 9.62135e-6;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.16985e-6;
-
-			}
-		}
+		LOG(FATAL) << "Cross section not available or 0. Make sure that CrossSectionWeightProducer is run before SampleStitchingWeightProducer!";
 	}
-	else if (boost::regex_search(product.m_nickname, boost::regex("DY.?JetsToLLM(50|150)_RunIISpring16", boost::regex::icase | boost::regex::extended)))
+	else if(SafeMap::GetWithDefault(product.m_weights, std::string("numberGeneratedEventsWeight"), -1.) <= 0.)
 	{
-		if (product.m_genDiLeptonBoson.mass() < 150.0)
-		{
-			if ((nPartons == 0) || (nPartons >= 5))
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.208008366e-4;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.208008366e-4;
-			}
-			else if (nPartons == 1)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.62772301e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.62772301e-5;
-			}
-			else if (nPartons == 2)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.75930713e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.75930713e-5;
-			}
-			else if (nPartons == 3)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.83929231e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.83929231e-5;
-			}
-			else
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.41810906e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.41810906e-5;
-			}
-		}
-		else
-		{
-			if ((nPartons == 0) || (nPartons >= 5))
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.208008366e-4;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.3134972e-6;
-			}
-			else if (nPartons == 1)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.62772301e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.2277715e-6;
-			}
-			else if (nPartons == 2)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.75930713e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.2347374e-6;
-			}
-			else if (nPartons == 3)
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.83929231e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.2385174e-6;
-			}
-			else
-			{
-				product.m_optionalWeights["stitchWeightZLL"] = 1.41810906e-5;
-				product.m_optionalWeights["stitchWeightZTT"] = 1.2142337e-6;
-
-			}
-		}
-	}
-	else if (boost::regex_search(product.m_nickname, boost::regex("W.?JetsToLNu_RunIIFall15", boost::regex::icase | boost::regex::extended)))
-	{
-		if ((nPartons == 0) || (nPartons >= 5))
-		{
-			product.m_optionalWeights["stitchWeightWJ"] = 1.3046006677e-3;
-		}
-		else if (nPartons == 1)
-		{
-			product.m_optionalWeights["stitchWeightWJ"] = 2.162338159e-4;
-		}
-		else if (nPartons == 2)
-		{
-			product.m_optionalWeights["stitchWeightWJ"] = 1.159006627e-4;
-		}
-		else if (nPartons == 3)
-		{
-			product.m_optionalWeights["stitchWeightWJ"] = 5.82002641e-5;
-		}
-		else
-		{
-			product.m_optionalWeights["stitchWeightWJ"] = 6.27558901e-05;
-		}
-	}
-	else if (boost::regex_search(product.m_nickname, boost::regex("W.?JetsToLNu_RunIISpring16", boost::regex::icase | boost::regex::extended)))
-	{
-		if ((nPartons == 0) || (nPartons >= 5))
-		{
-			product.m_optionalWeights["stitchWeightWJ"] = 2.192495462e-3;
-		}
-		else if (nPartons == 1)
-		{
-			product.m_optionalWeights["stitchWeightWJ"] = 2.475489115e-4;
-		}
-		else if (nPartons == 2)
-		{
-			product.m_optionalWeights["stitchWeightWJ"] = 1.213458342e-4;
-		}
-		else if (nPartons == 3)
-		{
-			product.m_optionalWeights["stitchWeightWJ"] = 5.716934e-5;
-		}
-		else
-		{
-			product.m_optionalWeights["stitchWeightWJ"] = 6.27887343e-5;
-		}
+		LOG(FATAL) << "Number of generated events not available or 0. Make sure that NumberGeneratedEventsWeightProducer is run before SampleStitchingWeightProducer!";
 	}
 	else
 	{
-		LOG(FATAL) << "Stitching weights not implemented for nickname " << product.m_nickname << ": check config settings!";
-	}*/
+		int nPartons = event.m_genEventInfo->lheNOutPartons >= 5 ? 0 : event.m_genEventInfo->lheNOutPartons;
+		product.m_weights["sampleStitchingWeight"] = SafeMap::Get(stitchingWeightsByIndex, size_t(nPartons)).at(0) / product.m_weights["numberGeneratedEventsWeight"] / product.m_weights["crossSectionPerEventWeight"];
+	}
 }

--- a/KappaAnalysis/src/Producers/SampleStitchingWeightProducer.cc
+++ b/KappaAnalysis/src/Producers/SampleStitchingWeightProducer.cc
@@ -25,27 +25,8 @@ void SampleStitchingWeightProducer::Produce( KappaEvent const& event,
 	product.m_weights["crossSectionPerEventWeight"] = 1.0;
 	product.m_weights["numberGeneratedEventsWeight"] = 1.0;
 	
-	/// size_t(0): DY.?JetsToLLM50
-	/// size_t(1): DY.?JetsToLLM150
-	/// size_t(2): W.?JetsToLNu
 	int nPartons = event.m_genEventInfo->lheNOutPartons >= 5 ? 0 : event.m_genEventInfo->lheNOutPartons;
-	if (boost::regex_search(product.m_nickname, boost::regex("DY.?JetsToLLM(50|150)", boost::regex::icase | boost::regex::extended)))
-	{
-		if (product.m_genDiLeptonBoson.mass() < 150.0)
-		{
-			product.m_optionalWeights["stitchWeightZLL"] = SafeMap::Get(stitchingWeightsByIndex, size_t(0)).at(nPartons);
-			product.m_optionalWeights["stitchWeightZTT"] = SafeMap::Get(stitchingWeightsByIndex, size_t(0)).at(nPartons);
-		}
-		else
-		{
-			product.m_optionalWeights["stitchWeightZLL"] = SafeMap::Get(stitchingWeightsByIndex, size_t(0)).at(nPartons);
-			product.m_optionalWeights["stitchWeightZTT"] = SafeMap::Get(stitchingWeightsByIndex, size_t(1)).at(nPartons);
-		}
-	}
-	else if (boost::regex_search(product.m_nickname, boost::regex("W.?JetsToLNu", boost::regex::icase | boost::regex::extended)))
-	{
-		product.m_optionalWeights["stitchWeightWJ"] = SafeMap::Get(stitchingWeightsByIndex, size_t(2)).at(nPartons);
-	}
+	product.m_optionalWeights["stitchWeight"] = SafeMap::Get(stitchingWeightsByIndex, size_t(nPartons)).at(0);
 	/*if (boost::regex_search(product.m_nickname, boost::regex("DY.?JetsToLLM(50|150)_RunIIFall15", boost::regex::icase | boost::regex::extended)))
 	{
 		if (product.m_genDiLeptonBoson.mass() < 150.0)
@@ -211,9 +192,9 @@ void SampleStitchingWeightProducer::Produce( KappaEvent const& event,
 		{
 			product.m_optionalWeights["stitchWeightWJ"] = 6.27887343e-5;
 		}
-	}*/
+	}
 	else
 	{
 		LOG(FATAL) << "Stitching weights not implemented for nickname " << product.m_nickname << ": check config settings!";
-	}
+	}*/
 }


### PR DESCRIPTION
Hi,

the changes introduced by this PR will enable us to supply the stitching weights via a json file since they are hardcoded at the moment. I performed tests to evaluate whether this changes any distributions compared to the old way and everything looks fine. You can find the control plots [here](https://anehrkor.web.cern.ch/anehrkor/plots_archive/2016_07_12/plots/control_plots/).

IMPORTANT: This will require you to reproduce your Artus ntuples if you use these weights in your analysis.

Unless there are any objections, I will merge this PR Friday afternoon.

Cheers,
Alex