### PR TITLE
HarryFaster

### DIFF
--- a/HarryPlotter/python/input_modules/inputroot.py
+++ b/HarryPlotter/python/input_modules/inputroot.py
@@ -64,6 +64,8 @@ class InputRoot(inputfile.InputFile):
 		                                help="Keep trees in the plot data object during the complete run. [Default: %(default)s]")
 		self.input_options.add_argument("--read-config", nargs="?", type="bool", default=False, const=True,
 		                                help="Read in the config stored in Artus ROOT outputs. [Default: %(default)s]")
+		self.input_options.add_argument("--n-cores", type=int, default=1,
+		                                help="Number of cores per Harry Plotter call. [Default: %(default)s]")
 
 	def prepare_args(self, parser, plotData):
 		super(InputRoot, self).prepare_args(parser, plotData)
@@ -89,7 +91,7 @@ class InputRoot(inputfile.InputFile):
 			self.read_input_json_dicts(plotData)
 
 	def run(self, plotData):
-		p = Pool(20)
+		p = Pool(plotData.plotdict["n_cores"])
 		histogram_from_tree_kwargs = []
 		histogram_from_tree_nicks = []
 		root_tools = roottools.RootTools()


### PR DESCRIPTION
Dear Harry users,

first: this is an experimental commit and not yet meant for merging, just for testing.

Since already a single controlPlot takes six minutes, this was just unacceptable for me when developing things. I therefore parallelized the histogram_from_tree function in the way you can see below. This speeds up the same plot from six minutes to less than one minute (from SSD on our new portal machine).

The modifications that were necessary go pretty deep. histogram_from_tree function has to be a staticfunction. This means the binning functionalities can't work any more and the binning string is re-calculated for each histogram. Is anyone even still using this functionality?

The progress bar unfortunately becomes meaningless; it's already at 100% when the parallelized TTree.Draw() command even starts. This could in principle be solved by using map_async; but this would mean the results are not guaranteed to be in the same order which brings additional problems with it.

The TTree itself can also not be returned any more. This is anyway the default behaviour currently.

I expect the speedup to be negligible in case one uses the makePlots scripts that already have the functionality to use several processes; but I did not test it yet.

I would like to invite everyone to test it and give feedback.